### PR TITLE
django setup improvements

### DIFF
--- a/examples/django-single-file.py
+++ b/examples/django-single-file.py
@@ -5,19 +5,6 @@ from django.conf import settings
 from django.core.management import execute_from_command_line
 from django.http import HttpResponse
 from django.urls import path
-import asyncio, logging, ngrok, os, sys
-
-# Set env variable to protect against the autoreloader.
-if os.getenv("NGROK_LISTENER_RUNNING") is None:
-    os.environ["NGROK_LISTENER_RUNNING"] = "true"
-    logging.basicConfig(level=logging.INFO)
-
-    async def setup():
-        listener = await ngrok.default()
-        listener.forward("localhost:8080")
-
-    asyncio.run(setup())
-
 
 async def home(request):
     response = HttpResponse("Hello")
@@ -30,9 +17,12 @@ settings.configure(
     MIDDLEWARE=[
         "django.middleware.common.CommonMiddleware"
     ],  # CommonMiddleware adds Content-Length header
+    INSTALLED_APPS = [
+        "ngrok_extra.django",
+    ],
     ROOT_URLCONF=__name__,
     SECRET_KEY="a-bad-secret",  # Insecure! Change this
 )
 urlpatterns = [path("", home)]
 
-execute_from_command_line([__name__, "runserver", "8080"])
+execute_from_command_line([__name__, "runserver"])

--- a/examples/djangosite/djangosite/settings.py
+++ b/examples/djangosite/djangosite/settings.py
@@ -40,6 +40,9 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    # """Added by ngrok"""
+    "ngrok_extra.django", # ngrok must come before staticfiles as they both override runserver
+    # """End added by ngrok"""
     "django.contrib.staticfiles",
 ]
 

--- a/examples/djangosite/manage.py
+++ b/examples/djangosite/manage.py
@@ -5,22 +5,6 @@ import sys
 
 
 def main():
-    """Added by ngrok"""
-    # This block handles 'make rundjangosite' which uses this manage.py as the entry point.
-    # Set env variable to protect against the autoreloader.
-    if os.getenv("NGROK_LISTENER_RUNNING") is None:
-        os.environ["NGROK_LISTENER_RUNNING"] = "true"
-        import asyncio, multiprocessing, ngrok
-
-        async def setup():
-            listen = sys.argv[2] if len(sys.argv) > 2 else "localhost:8000"
-            listener = await ngrok.default()
-            print(f"Forwarding to {listen} from ingress url: {listener.url()}")
-            listener.forward(listen)
-
-        asyncio.run(setup())
-    """End added by ngrok"""
-
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "djangosite.settings")
     try:

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -6,3 +6,4 @@ streamlit==1.22.0
 tornado==6.3.1
 uvicorn==0.21.0
 Werkzeug==2.2.2
+-e ./ngrok_extra # must run the install command from the toplevel dir


### PR DESCRIPTION
# Why
django users that want to use ngrok for their development workflow shouldn't need to modify their manage.py

# How
Implement an ngrok django app. At the moment the only thing this app does is move the custom manage.py logic into a runserver command that:
Starts a connection to ngrok forwarding to the addr and port the default runserver command parsed
Calls the default runserver command's run method.
IF the user has specified that they want to use staticfiles then we hand off to the staticfiles runserver command instead.

# Verification
`make run-djangosite` uses the staticfiles app so we see
`Delegating django runserver to django.contrib.staticfiles.management.commands.runserver`
```
└─> make run-djangosite 
. venv/bin/activate && maturin develop
📦 Including license file "/home/james/ngrok-python/LICENSE-APACHE"
📦 Including license file "/home/james/ngrok-python/LICENSE-MIT"
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
🐍 Not using a specific python interpreter
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
📦 Built wheel for abi3 Python ≥ 3.7 to /tmp/nix-shell.zzDqcA/.tmpRbj5on/ngrok-1.0.0-cp37-abi3-linux_x86_64.whl
🛠 Installed ngrok-1.0.0
. venv/bin/activate && pip install -r examples/requirements.txt --quiet

[notice] A new release of pip is available: 23.0.1 -> 24.0
[notice] To update, run: pip install --upgrade pip
. venv/bin/activate && python ./examples/djangosite/manage.py runserver localhost:1234
Forwarding to localhost:1234 from ingress url: https://2f6405d92350.ngrok.app/
ngrok connection established, starting django server...
Delegating django runserver to django.contrib.staticfiles.management.commands.runserver
Watching for file changes with StatReloader
Performing system checks...

System check identified no issues (0 silenced).

You have 18 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, sessions.
Run 'python manage.py migrate' to apply them.
February 28, 2024 - 21:23:16
Django version 4.1.7, using settings 'djangosite.settings'
Starting development server at http://localhost:1234/
Quit the server with CONTROL-C.
[28/Feb/2024 21:23:21] "GET / HTTP/1.1" 200 10681
[28/Feb/2024 21:23:21] "GET /static/admin/css/fonts.css HTTP/1.1" 200 423
[28/Feb/2024 21:23:21] "GET /static/admin/fonts/Roboto-Bold-webfont.woff HTTP/1.1" 200 86184
Not Found: /favicon.ico
[28/Feb/2024 21:23:21] "GET /favicon.ico HTTP/1.1" 404 2122
[28/Feb/2024 21:23:21] "GET /static/admin/fonts/Roboto-Light-webfont.woff HTTP/1.1" 200 85692
[28/Feb/2024 21:23:21] "GET /static/admin/fonts/Roboto-Regular-webfont.woff HTTP/1.1" 200 85876
```

Whereas `make run-django` does not and we see
`Delegating django runserver to django.core.management.commands.runserver`

```
└─> make run-django
. venv/bin/activate && maturin develop
📦 Including license file "/home/james/ngrok-python/LICENSE-APACHE"
📦 Including license file "/home/james/ngrok-python/LICENSE-MIT"
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
🐍 Not using a specific python interpreter
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
📦 Built wheel for abi3 Python ≥ 3.7 to /tmp/nix-shell.zzDqcA/.tmp481khW/ngrok-1.0.0-cp37-abi3-linux_x86_64.whl
🛠 Installed ngrok-1.0.0
. venv/bin/activate && pip install -r examples/requirements.txt --quiet

[notice] A new release of pip is available: 23.0.1 -> 24.0
[notice] To update, run: pip install --upgrade pip
. venv/bin/activate && python ./examples/django-single-file.py
Forwarding to 127.0.0.1:8000 from ingress url: https://77c57619c360.ngrok.app/
ngrok connection established, starting django server...
Delegating django runserver to django.core.management.commands.runserver
Watching for file changes with StatReloader
Performing system checks...

System check identified no issues (0 silenced).
February 28, 2024 - 21:22:18
Django version 4.1.7, using settings None
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
[28/Feb/2024 21:22:24] "GET / HTTP/1.1" 200 5
Not Found: /favicon.ico
[28/Feb/2024 21:22:24] "GET /favicon.ico HTTP/1.1" 404 2109
```

We can see that the port selection of the user is honored as the first example uses `1234`
`Forwarding to localhost:1234 from ingress url: https://2f6405d92350.ngrok.app/`
While the second uses the default (non-specified) `8000`
`Forwarding to 127.0.0.1:8000 from ingress url: https://77c57619c360.ngrok.app/`