### PR TITLE
django asgi simplifications

### DIFF
--- a/examples/djangosite/djangosite/ngrok-asgi.py
+++ b/examples/djangosite/djangosite/ngrok-asgi.py
@@ -9,29 +9,10 @@ https://docs.djangoproject.com/en/4.1/howto/deployment/asgi/
 
 import os
 
-from django.core.asgi import get_asgi_application
+# All a user needs to do is import from `ngrok_extra.django.asgi` rather than `django.core.asgi` to get the ngrok functionality.
+from ngrok_extra.django.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "djangosite.settings")
 
-application = get_asgi_application()
-
-"""Added by ngrok"""
 # This block handles 'make run-django-uvicorn' and 'make run-django-gunicorn' which uses this asgi.py as the entry point.
-# Set env variable to protect against the gunicorn autoreloader.
-if os.getenv("NGROK_LISTENER_RUNNING") is None:
-    os.environ["NGROK_LISTENER_RUNNING"] = "true"
-    import asyncio, multiprocessing, ngrok, sys
-
-    async def setup():
-        listen = "localhost:8000"
-        listener = await ngrok.default()
-        print(f"Forwarding to {listen} from ingress url: {listener.url()}")
-        listener.forward(listen)
-
-    try:
-        running_loop = asyncio.get_running_loop()
-        running_loop.create_task(setup())
-    except RuntimeError:
-        # no running loop, run on its own
-        asyncio.run(setup())
-"""End added by ngrok"""
+application = get_asgi_application()

--- a/examples/djangosite/djangosite/urls.py
+++ b/examples/djangosite/djangosite/urls.py
@@ -15,7 +15,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from .views import home
 
 urlpatterns = [
+    path("", home),
     path("admin/", admin.site.urls),
 ]

--- a/examples/djangosite/djangosite/views.py
+++ b/examples/djangosite/djangosite/views.py
@@ -1,0 +1,6 @@
+from django.http import HttpResponse
+
+
+async def home(request):
+    response = HttpResponse("Hello")
+    return response

--- a/ngrok_extra/ngrok_extra/django/asgi.py
+++ b/ngrok_extra/ngrok_extra/django/asgi.py
@@ -1,0 +1,19 @@
+import os
+from django.core.asgi import get_asgi_application as _get_asgi_application
+from ngrok_extra.django.listener import setup
+
+def get_asgi_application():
+    # This block handles 'make run-django-uvicorn' and 'make run-django-gunicorn' which uses this asgi.py as the entry point.
+    # Set env variable to protect against the gunicorn autoreloader.
+    if os.getenv("NGROK_LISTENER_RUNNING") is None:
+        os.environ["NGROK_LISTENER_RUNNING"] = "true"
+        import asyncio
+
+        try:
+            running_loop = asyncio.get_running_loop()
+            running_loop.create_task(setup())
+        except RuntimeError:
+            # no running loop, run on its own
+            asyncio.run(setup())
+
+    return _get_asgi_application()

--- a/ngrok_extra/ngrok_extra/django/listener.py
+++ b/ngrok_extra/ngrok_extra/django/listener.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+async def setup(listen="localhost:8000"):
+    import ngrok
+    # Note (james): This is where we can get settings for this app and pass them in if we want to.
+    # ngrok_config = getattr(settings, "NGROK_CONFIG", {})
+    # If hot reload is on though we'll need to handle that some other way.
+    listener = await ngrok.default()
+    print(f"Forwarding to {listen} from ingress url: {listener.url()}")
+    listener.forward(listen)


### PR DESCRIPTION
# Why

Rather than requiring users to add logic to their asgi.py we want them to adjust their import and gain ngrok functionality.

# How

Wrapper function in `ngrok_extra.django` for `get_asgi_application`. User imports it and uses it in place of the default `get_asgi_application`

Relocated the setup method to be shared for easier logic later.
# Validation

```
└─> make run-django-uvicorn        
. venv/bin/activate && maturin develop
📦 Including license file "/home/james/ngrok-python/LICENSE-APACHE"
📦 Including license file "/home/james/ngrok-python/LICENSE-MIT"
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
🐍 Not using a specific python interpreter
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
📦 Built wheel for abi3 Python ≥ 3.7 to /tmp/nix-shell.zzDqcA/.tmpMzkOoX/ngrok-1.0.0-cp37-abi3-linux_x86_64.whl
🛠 Installed ngrok-1.0.0
. venv/bin/activate && pip install -r examples/requirements.txt --quiet

[notice] A new release of pip is available: 23.0.1 -> 24.0
[notice] To update, run: pip install --upgrade pip
. venv/bin/activate && pushd ./examples/djangosite && python -m uvicorn djangosite.ngrok-asgi:application
~/ngrok-python/examples/djangosite ~/ngrok-python
INFO:     Started server process [1824328]
INFO:     Waiting for application startup.
INFO:     ASGI 'lifespan' protocol appears unsupported.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
Forwarding to localhost:8000 from ingress url: https://dcf6e4b21c99.ngrok.app
```

Other method still works.
```
└─> make run-djangosite    
. venv/bin/activate && maturin develop
📦 Including license file "/home/james/ngrok-python/LICENSE-APACHE"
📦 Including license file "/home/james/ngrok-python/LICENSE-MIT"
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.7
🐍 Not using a specific python interpreter
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
📦 Built wheel for abi3 Python ≥ 3.7 to /tmp/nix-shell.zzDqcA/.tmpuDNHyi/ngrok-1.0.0-cp37-abi3-linux_x86_64.whl
🛠 Installed ngrok-1.0.0
. venv/bin/activate && pip install -r examples/requirements.txt --quiet

[notice] A new release of pip is available: 23.0.1 -> 24.0
[notice] To update, run: pip install --upgrade pip
. venv/bin/activate && python ./examples/djangosite/manage.py runserver localhost:1234
Forwarding to localhost:1234 from ingress url: https://7419979fbf02.ngrok.app
Delegating django runserver to django.contrib.staticfiles.management.commands.runserver
Watching for file changes with StatReloader
Performing system checks...

System check identified no issues (0 silenced).

You have 18 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, sessions.
Run 'python manage.py migrate' to apply them.
February 29, 2024 - 00:23:41
Django version 4.1.7, using settings 'djangosite.settings'
Starting development server at http://localhost:1234/
Quit the server with CONTROL-C.
```
