### PR TITLE
Read policies from an NGROK_CONFIG block and apply them.

### DIFF
--- a/examples/djangosite/djangosite/settings.py
+++ b/examples/djangosite/djangosite/settings.py
@@ -128,3 +128,26 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+NGROK_CONFIG = {
+    "policies": {
+        "inbound": [
+        ],
+        "outbound": [
+            {
+                "expressions": [],
+                "name": "",
+                "actions": [
+                {
+                    "type": "add-headers",
+                    "config": {
+                    "headers": {
+                        "added-header": "added-header-value"
+                    }
+                    }
+                }
+                ]
+            }
+        ]
+    }
+}

--- a/examples/djangosite/djangosite/settings.py
+++ b/examples/djangosite/djangosite/settings.py
@@ -129,9 +129,20 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# Warning: Hot reloading of this config is not supported.
 NGROK_CONFIG = {
     "policies": {
         "inbound": [
+        {
+            "expressions": [
+                "req.URL.contains('/admin')",
+            ],
+            "actions": [
+            {
+                "type": "deny" # by denying access we can make "admin" only available locally.
+            }
+            ]
+        }
         ],
         "outbound": [
             {

--- a/ngrok_extra/ngrok_extra/django/listener.py
+++ b/ngrok_extra/ngrok_extra/django/listener.py
@@ -1,10 +1,24 @@
+import json
 from django.conf import settings
 
 async def setup(listen="localhost:8000"):
     import ngrok
     # Note (james): This is where we can get settings for this app and pass them in if we want to.
-    # ngrok_config = getattr(settings, "NGROK_CONFIG", {})
     # If hot reload is on though we'll need to handle that some other way.
-    listener = await ngrok.default()
+    ngrok_config = getattr(settings, "NGROK_CONFIG", {})
+    listener = None
+    if ngrok_config:
+        listener = await listener_from_config(ngrok_config)
+    else:
+        listener = await ngrok.default()
     print(f"Forwarding to {listen} from ingress url: {listener.url()}")
     listener.forward(listen)
+
+async def listener_from_config(config):
+    import ngrok
+    session = await ngrok.SessionBuilder().authtoken_from_env().connect()
+    listener = session.http_endpoint()
+    policies = config.get("policies", {})
+    if policies:
+        listener = listener.policy(json.dumps(policies))
+    return await listener.listen()

--- a/ngrok_extra/ngrok_extra/django/listener.py
+++ b/ngrok_extra/ngrok_extra/django/listener.py
@@ -4,7 +4,7 @@ from django.conf import settings
 async def setup(listen="localhost:8000"):
     import ngrok
     # Note (james): This is where we can get settings for this app and pass them in if we want to.
-    # If hot reload is on though we'll need to handle that some other way.
+    # Hot reloading of this config is not supported.
     ngrok_config = getattr(settings, "NGROK_CONFIG", {})
     listener = None
     if ngrok_config:


### PR DESCRIPTION
This change demonstrates reading a policy block from settings.py and applying it at _startup_. It does not handle hot reloads of these settings.