### PR TITLE
Hot reload of config working in django

### DIFF
--- a/examples/djangosite/djangosite/settings.py
+++ b/examples/djangosite/djangosite/settings.py
@@ -129,8 +129,8 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-# Warning: Hot reloading of this config is not supported.
 NGROK_CONFIG = {
+    "domain": "", # Warning: Only when a domain is specified here is hot reloading of this config is supported.
     "policies": {
         "inbound": [
         {

--- a/ngrok_extra/ngrok_extra/django/asgi.py
+++ b/ngrok_extra/ngrok_extra/django/asgi.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from django.core.asgi import get_asgi_application as _get_asgi_application
 from ngrok_extra.django.listener import setup
@@ -7,7 +8,6 @@ def get_asgi_application():
     # Set env variable to protect against the gunicorn autoreloader.
     if os.getenv("NGROK_LISTENER_RUNNING") is None:
         os.environ["NGROK_LISTENER_RUNNING"] = "true"
-        import asyncio
 
         try:
             running_loop = asyncio.get_running_loop()

--- a/ngrok_extra/ngrok_extra/django/listener.py
+++ b/ngrok_extra/ngrok_extra/django/listener.py
@@ -1,10 +1,11 @@
 import json
 from django.conf import settings
+from typing import Dict
 
 async def setup(listen="localhost:8000"):
     import ngrok
     # Note (james): This is where we can get settings for this app and pass them in if we want to.
-    # Hot reloading of this config is not supported.
+    # Hot reloading of this config is only supported when a domain is specified.
     ngrok_config = getattr(settings, "NGROK_CONFIG", {})
     listener = None
     if ngrok_config:
@@ -14,10 +15,13 @@ async def setup(listen="localhost:8000"):
     print(f"Forwarding to {listen} from ingress url: {listener.url()}")
     listener.forward(listen)
 
-async def listener_from_config(config):
+async def listener_from_config(config: Dict):
     import ngrok
     session = await ngrok.SessionBuilder().authtoken_from_env().connect()
     listener = session.http_endpoint()
+    domain = config.get("domain", "")
+    if domain:
+        listener = listener.domain(domain)
     policies = config.get("policies", {})
     if policies:
         listener = listener.policy(json.dumps(policies))

--- a/ngrok_extra/ngrok_extra/django/management/commands/runserver.py
+++ b/ngrok_extra/ngrok_extra/django/management/commands/runserver.py
@@ -1,4 +1,6 @@
+import asyncio
 import os
+from django.conf import settings
 
 from django.core.management.commands.runserver import Command as RunserverCommand
 from django.apps import apps
@@ -17,11 +19,24 @@ class Command(RunserverCommand):
     def run(self, **options):
         """Start the ngrok connection and hand off to django server."""
         # This block handles 'make rundjango' 'make rundjangosite' which uses the INSTALLED_APPS 'ngrok.django' as the entry point.
-        # Set env variable to protect against the autoreloader.
-        if os.getenv("NGROK_LISTENER_RUNNING") is None:
-            os.environ["NGROK_LISTENER_RUNNING"] = "true"
-            import asyncio
-            listen = f"{self.addr}:{self.port}" # RunserverCommand.handle sets this value for us.
-            asyncio.run(setup(listen))
-            print(f"Delegating django runserver to {RunserverCommand.__module__}")
+
+        use_reloader = options["use_reloader"] and self.config_supports_reload()
+        if not use_reloader or os.environ.get('RUN_MAIN') == 'true':
+            # we're either running without reloads or we're in the child autoreload process.
+            if os.getenv("NGROK_LISTENER_RUNNING") is None:
+                # Set env variable to protect against the autoreloader.
+                os.environ["NGROK_LISTENER_RUNNING"] = "true"
+
+                listen = f"{self.addr}:{self.port}" # RunserverCommand.handle sets this value for us.
+                asyncio.run(setup(listen))
+                print(f"Delegating django runserver to {RunserverCommand.__module__}")
+        elif use_reloader:
+            print("Reloader is on waiting for child process to start ngrok.")
+        else:
+            print("ngrok already running.")
         super().run(**options)
+
+    @staticmethod
+    def config_supports_reload():
+        ngrok_config = getattr(settings, "NGROK_CONFIG", {})
+        return ngrok_config and ngrok_config.get("domain", "") != ""


### PR DESCRIPTION
The agent will be started in the parent process when:
Hot reload is disabled `--no-reload` OR the config doesn't specify a `domain`
The agent will be started in the child (autoreloading) process when:
Hot reload is enabled AND the config specifies a `domain`